### PR TITLE
Clamp the openedAt variable between window.y and window.y + window.height

### DIFF
--- a/kwin4_effects_foldpopups/contents/code/main.js
+++ b/kwin4_effects_foldpopups/contents/code/main.js
@@ -92,6 +92,9 @@ var fadingPopupsEffect = {
             return;
         }
         openedAt = effects.cursorPos.y;
+        if(openedAt < window.y) openedAt = window.y;
+        else if(openedAt > window.y + window.height) openedAt = window.y + window.height;
+
         window.setData(Effect.WindowForceBlurRole, true);
         window.foldAnimation1 = animate({
             window: window,


### PR DESCRIPTION
Hi! The new way of animating looks really great on context menus. But notification windows, onscreen windows and splash screens because of the openedAt variable being too far off from the actual window. In this PR I clamp the openedAt variable between window.y, which is the y coordinate of the top of the window, and window.y + window.height which is the y coordinate of the bottom of the window to make this new animation look great on those windows.